### PR TITLE
Set "main" entry point properly so we can load the library through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "8bit",
   "version": "0.0.1",
   "description": "8Bit.js Audio Library - Write music using 8bit oscillation sounds.",
-  "main": "8bit.js",
+  "main": "src/8bit.js",
   "repository": {
     "type": "git",
     "url": "ssh://git@stash.4mation.com.au:7999/game/audio.git"


### PR DESCRIPTION
Not sure if it's just me, but setting the `main` property of the package.json should make sure we can just call

```
var EightBit = require('8bit');
```

in Node.

Or I've missed something and doing something wrong (very possible).
