### PR TITLE
Default onFinishedCallback

### DIFF
--- a/src/8bit.js
+++ b/src/8bit.js
@@ -65,7 +65,7 @@
                 self.stop(false);
                 if (loop) {
                     self.play();
-                } else {
+                } else if(typeof cb === 'function') {
                     cb();
                 }
             },


### PR DESCRIPTION
By default, the onFinishedCallback is undefined, which can give errors when play() is finished. Line 68 now checks to make sure cb is a function.
